### PR TITLE
remove photobucket image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 #### Information Management System for HeNN Elibrary project
 
-![Project Snapshot](http://i76.photobucket.com/albums/j5/alexshr/elims_info_zps5uxvj2ew.png)
-
 **E-Library information Management System** is the integrated website for E-library admins,
 system admins and users. The website provides complete information about HeNN E-Library
 project. The information about each individual sites, its geolocation, status and pictures.
@@ -15,21 +13,21 @@ of projects and the monitoring timetable. Add new deployment sites and their inf
 edit the existing ones. The Admin can generate reports based on information filled by 
 system admin on arrival from the site. Admin can make all type of new users including another admin. 
 
-2. **System admin(elibrary deployment/monitoring team member)**: The system admins can edit 
-details about the site but cannot add new site, write reports about their recent visit 
-and submit easily after their visit to sites. System admin can create new system admin 
-or user account but cannot create Admin account.
+2. **System admin(elibrary deployment/monitoring team member)**:
+- The system admins can edit details about the site but cannot add new site.
+- write reports about their recent visit and submit easily after their visit to sites.
+- System admin can create new system admin user account but cannot create Admin account.
 
-3. **User(consumer of the system- students,teachers and school staffs)**: The users from each
+3. **User(consumer of the system-students, teachers and school staffs)**: The users from each
 elibrary site can report current status of the site at any time or  file complaint about the
 system and ask for help via form. The Notification email should be pushed to sysadmin and admin
 as soon as complaint or problem is filed. 
 
 4. **website Guest/visitor**: Any guest/visitor can see general information about E-Library project,
-sites and map.This application should serve as a one stop for all required information.
+sites and map. This application should serve as a one stop for all required information.
 
 The map is being displayed when we click (site) button. this map has pointers to all the
-locations where project are being deployed. the geo position are stored in database table.
+locations where projects are being deployed. The geo position are stored in database table.
 
 Test users created/sql updated:
 


### PR DESCRIPTION
Photobucket recently blocked the hot-linking of the images. Now, we
have to pay to use photobucket as image storage site. So removing the
photobucket link from the documentation makes sense.